### PR TITLE
Systemd services for the legacy-installer

### DIFF
--- a/provisioning/roles/common/defaults/main.yml
+++ b/provisioning/roles/common/defaults/main.yml
@@ -29,7 +29,7 @@ java_home_dir: "/usr/lib/jvm/java-7-oracle"
 # Database user configuration (used by the SMART-on-FHIR server)
 postgres_user: "fhir"
 postgres_password: "fhir"
-
+postgresql_version: "9.5"
 # Password for the Java keystore used by the authorization server (please change)
 keystore_password: "changeme"
 

--- a/provisioning/roles/common/tasks/api-server.yml
+++ b/provisioning/roles/common/tasks/api-server.yml
@@ -17,12 +17,19 @@
           password={{postgres_password}}
           role_attr_flags=SUPERUSER
           
-- name: configure api server service
+- name: configure api server service(Upstart)
   tags: [smart_on_fhir, reset_db]
   template: src=api-server.conf.j2
             dest=/etc/init/api-server.conf
             owner=root group=root mode=0644
   register: sof_service
+  when: systemdPath.stat.isdir is not defined
+
+- name: configure api server service(systemd)
+  tags: [smart_on_fhir, reset_db]
+  template: src=api-server.service.j2
+            dest=/lib/systemd/system/api-server.service
+  when: systemdPath.stat.isdir is defined and systemdPath.stat.isdir
 
 - name: checkout api server
   tags: [smart_on_fhir, reset_db]

--- a/provisioning/roles/common/tasks/auth-server.yml
+++ b/provisioning/roles/common/tasks/auth-server.yml
@@ -1,9 +1,16 @@
-- name: configure auth server service
+- name: configure auth server service(Upstart)
   tags: [auth]
   template: src=auth-server.conf.j2
             dest=/etc/init/auth-server.conf
             owner=root group=root mode=0644
   register: auth_service
+  when: systemdPath.stat.isdir is not defined
+
+- name: configure auth server service(systemd)
+  tags: [smart_on_fhir, reset_db]
+  template: src=auth-server.service.j2
+            dest=/lib/systemd/system/auth-server.service
+  when: systemdPath.stat.isdir is defined and systemdPath.stat.isdir
 
 - name: checkout auth server
   tags: [auth]

--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -1,3 +1,9 @@
+- name: check service manager for systemd
+  stat:
+    path: /usr/lib/systemd
+  register: systemdPath
+  ignore_errors: True
+
 - name: check host:port uniqueness
   tags: [general]
   fail: msg="each server must have unique host:port assigned"

--- a/provisioning/roles/common/templates/api-server.service.j2
+++ b/provisioning/roles/common/templates/api-server.service.j2
@@ -1,0 +1,25 @@
+[Unit]
+Description=Job that starts the SmartOnFhir Api-Server
+Documentation=man:foo(1)
+
+[Service]
+User={{username}}
+Environment=BASE_URL={{fhir_server_base}}
+Environment=AUTH={{fhir_server_use_auth|default('false')}}
+Environment=INTROSPECTION_URI={{fhir_server_introspection_uri|default('')}}
+Environment=REGISTER_URI={{fhir_server_register_uri|default('')}}
+Environment=AUTHORIZE_URI={{fhir_server_authorize_uri|default('')}}
+Environment=TOKEN_URI={{fhir_server_token_uri|default('')}}
+Environment=CLIENT_ID={{fhir_server_client|default('')}}
+Environment=CLIENT_SECRET={{fhir_server_password|default('')}}
+Environment=AUTH_CLIENT_ID={{auth_server_client|default('')}}
+Environment=TOKEN_CACHE_SPEC="maximumSize=1000,expireAfterWrite={{token_cache_duration}}"
+Environment=AUTH_CLIENT_SECRET={{auth_server_password|default('')}}
+Environment=JAVA_HOME={{java_home_dir}}
+WorkingDirectory={{install_dir}}/api-server/target
+ExecStart=/usr/bin/java -Djetty.port="3000" -Djetty.host="localhost" {% if auth_server_secure_http and not use_custom_ssl_certificates %} -Djavax.net.ssl.trustStore="{{install_dir}}/keystore" -Djavax.net.ssl.trustStorePassword="{{keystore_password}}" {% endif %} -jar /home/fhir/jetty-runner.jar --config /home/fhir/jetty.xml fhir-0.1.war
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+

--- a/provisioning/roles/common/templates/auth-server.service.j2
+++ b/provisioning/roles/common/templates/auth-server.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Job that starts the SmartOnFhir Api-Server
+Documentation=man:foo(1)
+
+[Service]
+User={{username}}
+WorkingDirectory={{install_dir}}
+ExecStart=/usr/bin/java -DBASE_URL="{{auth_server_base}}/"-DCONTEXT_FHIR_ENDPOINT="{{fhir_server_base}}" -DCONTEXT_RESOLVE_ENDPOINT="{{app_server_base}}" -DCONTEXT_USERNAME="{{fhir_server_client}}" -DCONTEXT_PASSWORD="{{fhir_server_password}}" -Dldap.server="{{ldap_server_uri}}" -Dldap.url="{{ldap_server_uri}}" -Dldap.base="ou=People,{{ldap_server_base}}" -Djetty.port="4000" -Djetty.host="localhost"{% if ldap_server_tls or fhir_server_secure_http %} -Djavax.net.ssl.trustStore="{{install_dir}}/keystore" -Djavax.net.ssl.trustStorePassword="{{keystore_password}}" {% endif %} -jar jetty-runner.jar --config {{install_dir}}/jetty.xml {{auth_server_war}}
+
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Since this project has been created, ubuntu has moved their service controller our of Upstart and into systemd. This pull requests updates the installer to recognize a systemd path on the host machine, and creates a .service file instead of a .conf file for the api-server and auth-server services.